### PR TITLE
fix: move incidents on top of reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
           </div>
         </div>
       </div>
-      <div id="reports" class="reportContainer"></div>
       <div id="incidents" class="incidentsContainer">
         <div class="statusContainer">
           <div class="statusHeader">
@@ -60,6 +59,7 @@
           </div>
         </div>
       </div>
+      <div id="reports" class="reportContainer"></div>
     </div>
     <footer>
       <a href="https://keyspace.cloud/"


### PR DESCRIPTION
Moves the outage announcement above the status report widgets